### PR TITLE
Remove Degree and Semester fields from application form

### DIFF
--- a/backend/src/db/migrations/0000_empty_texas_twister.sql
+++ b/backend/src/db/migrations/0000_empty_texas_twister.sql
@@ -11,8 +11,6 @@ CREATE TABLE IF NOT EXISTS "applications" (
 	"email" varchar(255) NOT NULL,
 	"phone" varchar(50),
 	"course_id" integer NOT NULL,
-	"semester" integer,
-	"degree" varchar(50),
 	"experience" varchar,
 	"status" "applicationstatus" DEFAULT 'pending' NOT NULL,
 	"messaged" boolean DEFAULT false,

--- a/backend/src/db/migrations/meta/0000_snapshot.json
+++ b/backend/src/db/migrations/meta/0000_snapshot.json
@@ -44,18 +44,6 @@
           "primaryKey": false,
           "notNull": true
         },
-        "semester": {
-          "name": "semester",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "degree": {
-          "name": "degree",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
         "experience": {
           "name": "experience",
           "type": "varchar",

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -50,8 +50,6 @@ export const applications = pgTable('applications', {
   courseId: integer('course_id')
     .notNull()
     .references(() => courses.id),
-  semester: integer('semester'),
-  degree: varchar('degree', { length: 50 }),
   experience: varchar('experience'),
   status: applicationStatus('status').notNull().default('pending'),
   messaged: boolean('messaged').default(false),

--- a/backend/src/models/application.ts
+++ b/backend/src/models/application.ts
@@ -12,8 +12,6 @@ export const InsertApplication = BaseSchema.pick({
   email: true,
   phone: true,
   courseId: true,
-  semester: true,
-  degree: true,
 }).extend({
   fields: z.array(z.number().int().positive()),
 })
@@ -25,8 +23,6 @@ export const UpdateApplication = BaseSchema.partial()
     email: true,
     phone: true,
     courseId: true,
-    semester: true,
-    degree: true,
     messaged: true,
     talked: true,
     clubBriefed: true,

--- a/frontend/app/components/ApplicationDetailDialog.vue
+++ b/frontend/app/components/ApplicationDetailDialog.vue
@@ -79,15 +79,6 @@ const onSubmit = handleSubmit(async (values) => {
         <small class="sm:col-span-2">Please provide your private email address, not your THA email address.</small>
         <FormInputText name="phone" label="Phone" class="sm:col-span-2" />
 
-        <FormInputText name="degree" label="Degree" />
-        <FormInputNumber
-          name="semester"
-          label="Semester"
-          :use-grouping="false"
-          :min="0"
-          show-buttons
-        />
-
         <FormSelect
           name="courseId"
           label="Course"

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -209,8 +209,6 @@ function closeDetailDialog(): void {
           <Column field="firstName" header="First name" sortable />
           <Column field="lastName" header="Last name" sortable />
           <Column field="course.name" header="Course" sortable />
-          <Column field="semester" header="Semester" sortable />
-          <Column field="degree" header="Degree" sortable />
           <Column field="fields" header="Fields" sortable>
             <template #body="slotProps">
               {{ formatFields(slotProps.data.fields) }}

--- a/frontend/app/types/applicaion.schema.ts
+++ b/frontend/app/types/applicaion.schema.ts
@@ -6,8 +6,6 @@ export const AddApplication = z.object({
   lastName: z.string().max(100),
   email: z.string().email().max(255),
   phone: z.string().max(50).nullish(),
-  semester: z.number().nullish(),
-  degree: z.string().max(50).nullish(),
   courseId: z.number(),
   fields: z.array(z.number()),
   messaged: z.boolean().optional(),


### PR DESCRIPTION
Remove the "Degree" and "Semester" fields from the application form UI and update the backend to stop expecting or storing these fields.

* **Backend Changes:**
  - Remove the "degree" and "semester" columns from the "applications" table in `backend/src/db/migrations/0000_empty_texas_twister.sql`.
  - Remove the "degree" and "semester" columns from the "applications" table definition in `backend/src/db/migrations/meta/0000_snapshot.json`.
  - Remove the "degree" and "semester" fields from the `applications` table definition in `backend/src/db/schema.ts`.
  - Remove the "degree" and "semester" fields from the `InsertApplication` and `UpdateApplication` schemas in `backend/src/models/application.ts`.

* **Frontend Changes:**
  - Remove the input fields for "Degree" and "Semester" in `frontend/app/components/ApplicationDetailDialog.vue`.
  - Remove the columns for "Degree" and "Semester" in the applications table in `frontend/app/pages/index.vue`.
  - Remove the "degree" and "semester" fields from the `AddApplication` schema in `frontend/app/types/applicaion.schema.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GoliathLabs/applica/pull/2?shareId=a8ce8b58-00b1-469e-9efd-1f4b27d4b9e4).